### PR TITLE
Add external API config and extend models for real data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/
 .idea/
 *.swp
 *.swo
+.claude/settings.local.json
 
 # OS
 .DS_Store

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,9 @@
 FLASK_ENV=development
 FLASK_DEBUG=1
+
+# SerpApi for Amazon product search + reviews (250 searches/month free) - https://serpapi.com
+SERPAPI_API_KEY=your_serpapi_api_key_here
+SERPAPI_MONTHLY_LIMIT=250
+
+# How many days to cache reviews before re-fetching
+REVIEW_CACHE_DAYS=7

--- a/backend/config.py
+++ b/backend/config.py
@@ -21,3 +21,9 @@ class Config:
     # API
     API_PAGE_SIZE = 20
     API_MAX_PAGE_SIZE = 100
+
+    # External APIs
+    BESTBUY_API_KEY = os.getenv("BESTBUY_API_KEY", "")
+    SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY", "")
+    SERPAPI_MONTHLY_LIMIT = int(os.getenv("SERPAPI_MONTHLY_LIMIT", "250"))
+    REVIEW_CACHE_DAYS = int(os.getenv("REVIEW_CACHE_DAYS", "7"))

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,5 +1,6 @@
 from models.product import Product
 from models.review import Review
 from models.category import Category
+from models.api_usage import ApiUsage
 
-__all__ = ["Product", "Review", "Category"]
+__all__ = ["Product", "Review", "Category", "ApiUsage"]

--- a/backend/models/api_usage.py
+++ b/backend/models/api_usage.py
@@ -1,0 +1,15 @@
+import uuid
+from datetime import datetime
+from utils.database import db
+
+
+class ApiUsage(db.Model):
+    """Track external API usage for rate limiting"""
+
+    __tablename__ = "api_usage"
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    api_name = db.Column(db.String(50), nullable=False, index=True)
+    endpoint = db.Column(db.String(200))
+    product_id = db.Column(db.String(36), nullable=True)
+    called_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)

--- a/backend/models/product.py
+++ b/backend/models/product.py
@@ -17,6 +17,9 @@ class Product(db.Model):
     review_count = db.Column(db.Integer, default=0)
     image_url = db.Column(db.String(500))
     source_url = db.Column(db.String(500))
+    bestbuy_sku = db.Column(db.String(50), unique=True, nullable=True, index=True)
+    amazon_asin = db.Column(db.String(20), unique=True, nullable=True, index=True)
+    reviews_fetched_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/models/review.py
+++ b/backend/models/review.py
@@ -14,6 +14,7 @@ class Review(db.Model):
     source = db.Column(db.String(50), nullable=False)  # amazon, ebay, tiktok, etsy
     text = db.Column(db.Text, nullable=False)
     sentiment_score = db.Column(db.Float)  # -1 to 1
+    source_rating = db.Column(db.Float, nullable=True)  # Original 1-5 star rating from source
     pros = db.Column(db.Text)  # JSON array stored as text
     cons = db.Column(db.Text)  # JSON array stored as text
     scraped_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ flask-sqlalchemy>=3.1.0
 python-dotenv>=1.0.0
 sqlalchemy>=2.0.0
 pydantic>=2.0.0
+requests>=2.31.0

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -11,3 +11,15 @@ def health_check():
 @health_bp.route("/hello", methods=["GET"])
 def hello():
     return jsonify({"message": "Hello from revu-ai!"})
+
+
+@health_bp.route("/api-usage", methods=["GET"])
+def api_usage():
+    """Get SerpApi usage statistics for the current month"""
+    try:
+        from services.serpapi_client import SerpApiClient
+        client = SerpApiClient()
+        stats = client.get_usage_stats()
+        return jsonify(stats), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/backend/services/bestbuy_client.py
+++ b/backend/services/bestbuy_client.py
@@ -1,0 +1,93 @@
+"""Best Buy Products API client"""
+import requests
+from flask import current_app
+
+BESTBUY_BASE_URL = "https://api.bestbuy.com/v1"
+
+# Map Best Buy category IDs to Revu category slugs
+CATEGORY_MAP = {
+    "abcat0502000": "electronics",       # Laptops
+    "abcat0501000": "electronics",       # Desktops
+    "abcat0204000": "electronics",       # Headphones
+    "abcat0101000": "electronics",       # TVs
+    "pcmcat241600050001": "electronics", # Cell Phones
+    "abcat0904000": "electronics",       # Cameras
+    "abcat0912000": "electronics",       # Wearable Technology
+    "abcat0901000": "electronics",       # Home Audio
+    "pcmcat312300050015": "home-kitchen",    # Small Kitchen Appliances
+    "pcmcat242800050021": "health-wellness", # Health & Fitness
+}
+
+PRODUCT_FIELDS = ",".join([
+    "sku", "name", "shortDescription", "longDescription",
+    "salePrice", "regularPrice",
+    "customerReviewAverage", "customerReviewCount",
+    "image", "largeFrontImage", "thumbnailImage",
+    "categoryPath", "url",
+])
+
+
+class BestBuyClient:
+    def __init__(self, api_key=None):
+        self.api_key = api_key or current_app.config.get("BESTBUY_API_KEY", "")
+
+    def _request(self, path, params=None):
+        """Make an authenticated request to Best Buy API"""
+        if not self.api_key:
+            raise ValueError("BESTBUY_API_KEY not configured")
+
+        url = f"{BESTBUY_BASE_URL}/{path}"
+        default_params = {
+            "apiKey": self.api_key,
+            "format": "json",
+        }
+        if params:
+            default_params.update(params)
+
+        response = requests.get(url, params=default_params, timeout=15)
+        response.raise_for_status()
+        return response.json()
+
+    def get_products_by_category(self, category_id, page=1, page_size=20, min_reviews=10):
+        """Fetch products from a Best Buy category, sorted by review average descending."""
+        filter_str = (
+            f"(categoryPath.id={category_id}"
+            f"&customerReviewCount>={min_reviews})"
+        )
+        path = f"products{filter_str}"
+        params = {
+            "show": PRODUCT_FIELDS,
+            "sort": "customerReviewAverage.desc",
+            "page": page,
+            "pageSize": page_size,
+        }
+        return self._request(path, params)
+
+    def search_products(self, query, page=1, page_size=20):
+        """Search Best Buy products by keyword."""
+        path = f"products(search={query})"
+        params = {
+            "show": PRODUCT_FIELDS,
+            "sort": "customerReviewAverage.desc",
+            "page": page,
+            "pageSize": page_size,
+        }
+        return self._request(path, params)
+
+    @staticmethod
+    def convert_rating(bestbuy_rating):
+        """Convert Best Buy 1-5 scale to Revu 0-10 scale"""
+        if not bestbuy_rating:
+            return 0.0
+        return round(float(bestbuy_rating) * 2.0, 1)
+
+    @staticmethod
+    def map_category(category_path):
+        """Map Best Buy categoryPath list to a Revu category slug."""
+        if not category_path:
+            return "electronics"
+        for cat in category_path:
+            cat_id = cat.get("id", "")
+            if cat_id in CATEGORY_MAP:
+                return CATEGORY_MAP[cat_id]
+        return "electronics"

--- a/backend/services/review_service.py
+++ b/backend/services/review_service.py
@@ -1,0 +1,75 @@
+"""Service for fetching and caching product reviews from SerpApi"""
+from datetime import datetime, timedelta
+from flask import current_app
+from models.review import Review
+from services.serpapi_client import SerpApiClient
+from utils.database import db
+
+
+def fetch_reviews_for_product(product):
+    """
+    Fetch Amazon reviews for a product if cache is stale.
+    Returns True if new reviews were fetched, False if using cache.
+    """
+    cache_days = current_app.config.get("REVIEW_CACHE_DAYS", 7)
+
+    # Check if reviews are fresh enough
+    if product.reviews_fetched_at:
+        cache_cutoff = datetime.utcnow() - timedelta(days=cache_days)
+        if product.reviews_fetched_at > cache_cutoff:
+            return False  # Cache is still fresh
+
+    client = SerpApiClient()
+
+    # Step 1: If we don't have an ASIN, search Amazon for one
+    asin = product.amazon_asin
+    if not asin:
+        asin = client.search_amazon_asin(product.name, product.id)
+        if asin:
+            product.amazon_asin = asin
+            db.session.commit()
+        else:
+            # Rate limited or no results — mark as attempted
+            product.reviews_fetched_at = datetime.utcnow()
+            db.session.commit()
+            return False
+
+    # Step 2: Fetch reviews using ASIN
+    raw_reviews = client.get_amazon_reviews(asin, product.id)
+    if not raw_reviews:
+        # Rate limited or no reviews — mark as attempted
+        product.reviews_fetched_at = datetime.utcnow()
+        db.session.commit()
+        return False
+
+    # Step 3: Delete old Amazon reviews for this product
+    Review.query.filter_by(product_id=product.id, source="amazon").delete()
+
+    # Step 4: Insert new reviews
+    for raw in raw_reviews:
+        star_rating = raw.get("rating")
+        sentiment = SerpApiClient.convert_sentiment(star_rating)
+
+        review = Review(
+            product_id=product.id,
+            source="amazon",
+            text=raw.get("text", raw.get("title", "No review text")),
+            sentiment_score=sentiment,
+            source_rating=float(star_rating) if star_rating else None,
+        )
+
+        # Set basic pros/cons based on sentiment
+        if sentiment > 0.6:
+            review.set_pros([raw.get("title", "Positive review")])
+        elif sentiment < 0.3:
+            review.set_cons([raw.get("title", "Negative review")])
+
+        db.session.add(review)
+
+    # Step 5: Update product metadata
+    product.reviews_fetched_at = datetime.utcnow()
+    all_reviews = Review.query.filter_by(product_id=product.id).all()
+    product.review_count = len(all_reviews)
+
+    db.session.commit()
+    return True

--- a/backend/services/serpapi_client.py
+++ b/backend/services/serpapi_client.py
@@ -1,0 +1,164 @@
+"""SerpApi client for Amazon product search and review fetching"""
+import requests
+from datetime import datetime
+from flask import current_app
+from models.api_usage import ApiUsage
+from utils.database import db
+
+SERPAPI_BASE_URL = "https://serpapi.com/search"
+
+
+class SerpApiClient:
+    def __init__(self, api_key=None):
+        self.api_key = api_key or current_app.config.get("SERPAPI_API_KEY", "")
+
+    def _get_monthly_usage(self):
+        """Count SerpApi calls this month"""
+        now = datetime.utcnow()
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        return ApiUsage.query.filter(
+            ApiUsage.api_name == "serpapi",
+            ApiUsage.called_at >= month_start,
+        ).count()
+
+    def _can_make_request(self):
+        """Check if we're within the monthly limit (with 10-call buffer)"""
+        limit = current_app.config.get("SERPAPI_MONTHLY_LIMIT", 250)
+        usage = self._get_monthly_usage()
+        return usage < (limit - 10)
+
+    def _log_usage(self, endpoint, product_id=None):
+        """Log an API call for tracking"""
+        usage = ApiUsage(
+            api_name="serpapi",
+            endpoint=endpoint,
+            product_id=product_id,
+        )
+        db.session.add(usage)
+        db.session.commit()
+
+    def _request(self, params, product_id=None):
+        """Make an authenticated SerpApi request with usage tracking"""
+        if not self.api_key:
+            raise ValueError("SERPAPI_API_KEY not configured")
+
+        if not self._can_make_request():
+            return None  # Rate limited
+
+        params["api_key"] = self.api_key
+        endpoint = params.get("engine", "unknown")
+
+        response = requests.get(SERPAPI_BASE_URL, params=params, timeout=20)
+        response.raise_for_status()
+
+        self._log_usage(endpoint, product_id)
+        return response.json()
+
+    def search_amazon_products(self, query, product_id=None):
+        """
+        Search Amazon for products by keyword.
+        Returns list of product dicts with: asin, title, price, rating, reviews_count, image, link.
+        """
+        params = {
+            "engine": "amazon",
+            "amazon_domain": "amazon.com",
+            "k": query,
+        }
+        data = self._request(params, product_id)
+        if not data:
+            return []
+
+        results = data.get("organic_results", [])
+        products = []
+        for r in results:
+            asin = r.get("asin")
+            if not asin:
+                continue
+
+            # Extract price (SerpApi returns various price formats)
+            price = None
+            price_info = r.get("price", {})
+            if isinstance(price_info, dict):
+                price = price_info.get("extracted_value") or price_info.get("value")
+            elif isinstance(price_info, (int, float)):
+                price = price_info
+            if not price:
+                price = r.get("extracted_price")
+
+            products.append({
+                "asin": asin,
+                "title": r.get("title", ""),
+                "price": price,
+                "rating": r.get("rating"),
+                "reviews_count": r.get("reviews", {}).get("total") if isinstance(r.get("reviews"), dict) else None,
+                "image": r.get("thumbnail", ""),
+                "link": r.get("link", ""),
+            })
+        return products
+
+    def search_amazon_asin(self, product_name, product_id=None):
+        """Search Amazon for a product by name. Returns the ASIN of the top result."""
+        products = self.search_amazon_products(product_name, product_id)
+        if products:
+            return products[0].get("asin")
+        return None
+
+    def get_amazon_reviews(self, asin, product_id=None):
+        """Fetch reviews for an Amazon product by ASIN. Returns list of review dicts."""
+        params = {
+            "engine": "amazon_product",
+            "amazon_domain": "amazon.com",
+            "asin": asin,
+        }
+        data = self._request(params, product_id)
+        if not data:
+            return []
+
+        # SerpApi returns reviews in different paths depending on the response
+        reviews_raw = []
+
+        # Try reviews_results.reviews first (most common)
+        reviews_section = data.get("reviews_results", {})
+        if isinstance(reviews_section, dict):
+            reviews_raw = reviews_section.get("reviews", [])
+
+        # Fallback: top_reviews
+        if not reviews_raw:
+            reviews_raw = data.get("top_reviews", [])
+
+        # Fallback: reviews_information.authors_reviews
+        if not reviews_raw:
+            info = data.get("reviews_information", {})
+            if isinstance(info, dict):
+                reviews_raw = info.get("authors_reviews", [])
+
+        reviews = []
+        for r in reviews_raw:
+            review_text = r.get("body", "") or r.get("text", "") or r.get("title", "")
+            if not review_text:
+                continue
+            reviews.append({
+                "title": r.get("title", ""),
+                "text": review_text,
+                "rating": r.get("rating", 3),
+                "date": r.get("date", ""),
+            })
+        return reviews
+
+    def get_usage_stats(self):
+        """Return current month's usage statistics"""
+        limit = current_app.config.get("SERPAPI_MONTHLY_LIMIT", 250)
+        usage = self._get_monthly_usage()
+        return {
+            "used": usage,
+            "limit": limit,
+            "remaining": max(0, limit - usage),
+        }
+
+    @staticmethod
+    def convert_sentiment(star_rating):
+        """Convert Amazon 1-5 star rating to 0-1 sentiment score"""
+        if not star_rating:
+            return 0.5
+        rating = max(1, min(5, float(star_rating)))
+        return round((rating - 1) / 4.0, 2)

--- a/backend/sync.py
+++ b/backend/sync.py
@@ -1,0 +1,280 @@
+"""
+Sync script to populate products from Amazon via SerpApi.
+Run: python sync.py [--clean] [--limit N]
+
+Each search query costs 1 SerpApi call (~20 results per call).
+Default config uses ~10 queries = ~10 of your 250 monthly calls.
+"""
+import argparse
+from datetime import datetime
+from app import create_app
+from models.product import Product
+from models.category import Category
+from services.serpapi_client import SerpApiClient
+from utils.database import db
+
+
+# Categories with Amazon search queries to populate them
+# ~7 queries per category × 8 categories = ~56 SerpApi calls
+CATEGORY_SEARCHES = {
+    "electronics": [
+        "best wireless headphones 2025",
+        "best laptops 2025",
+        "best smartwatch 2025",
+        "best bluetooth speaker",
+        "best noise cancelling earbuds",
+        "best 4k monitor",
+        "best mechanical keyboard",
+    ],
+    "home-kitchen": [
+        "best air fryer",
+        "best robot vacuum",
+        "best instant pot pressure cooker",
+        "best coffee maker",
+        "best blender",
+        "best knife set kitchen",
+        "best air purifier home",
+    ],
+    "health-wellness": [
+        "best fitness tracker 2025",
+        "best massage gun",
+        "best yoga mat",
+        "best foam roller",
+        "best resistance bands set",
+        "best weight scale smart",
+        "best meditation cushion",
+    ],
+    "sports-outdoors": [
+        "best running shoes men",
+        "best running shoes women",
+        "best hiking backpack",
+        "best camping tent",
+        "best water bottle insulated",
+        "best cycling helmet",
+        "best adjustable dumbbells",
+    ],
+    "beauty-personal-care": [
+        "best electric toothbrush",
+        "best hair dryer",
+        "best electric shaver men",
+        "best skincare set",
+        "best hair straightener",
+        "best face moisturizer",
+        "best beard trimmer",
+    ],
+    "toys-games": [
+        "best board games adults",
+        "best lego sets 2025",
+        "best puzzle 1000 piece",
+        "best remote control car",
+        "best kids tablet",
+        "best drone with camera",
+        "best card games family",
+    ],
+    "fashion-accessories": [
+        "best mens wallet leather",
+        "best sunglasses polarized",
+        "best crossbody bag women",
+        "best watch men under 100",
+        "best backpack laptop",
+        "best winter gloves touchscreen",
+        "best belt men leather",
+    ],
+    "office-supplies": [
+        "best standing desk",
+        "best office chair ergonomic",
+        "best monitor stand",
+        "best desk lamp",
+        "best wireless mouse",
+        "best webcam 2025",
+        "best desk organizer",
+    ],
+}
+
+# All categories to ensure exist (even those without search queries yet)
+ALL_CATEGORIES = {
+    "electronics": "Electronics",
+    "home-kitchen": "Home & Kitchen",
+    "health-wellness": "Health & Wellness",
+    "sports-outdoors": "Sports & Outdoors",
+    "beauty-personal-care": "Beauty & Personal Care",
+    "toys-games": "Toys & Games",
+    "fashion-accessories": "Fashion & Accessories",
+    "office-supplies": "Office Supplies",
+}
+
+
+def run_migrations():
+    """Add new columns if they don't exist (SQLite-safe, idempotent)"""
+    migrations = [
+        "ALTER TABLE products ADD COLUMN bestbuy_sku VARCHAR(50)",
+        "ALTER TABLE products ADD COLUMN amazon_asin VARCHAR(20)",
+        "ALTER TABLE products ADD COLUMN reviews_fetched_at DATETIME",
+        "ALTER TABLE reviews ADD COLUMN source_rating FLOAT",
+    ]
+    for sql in migrations:
+        try:
+            db.session.execute(db.text(sql))
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+
+
+def ensure_categories():
+    """Create categories that don't exist yet"""
+    for slug, name in ALL_CATEGORIES.items():
+        existing = Category.query.filter_by(slug=slug).first()
+        if not existing:
+            cat = Category(name=name, slug=slug, product_count=0)
+            db.session.add(cat)
+    db.session.commit()
+
+
+def convert_amazon_rating(rating):
+    """Convert Amazon 1-5 star rating to Revu 0-10 scale"""
+    if not rating:
+        return 0.0
+    return round(float(rating) * 2.0, 1)
+
+
+def sync_products(limit_per_query=10, clean=False):
+    """Sync products from Amazon via SerpApi"""
+    app = create_app()
+
+    with app.app_context():
+        db.create_all()
+
+        if clean:
+            print("Cleaning existing data...")
+            from models.review import Review
+            from models.api_usage import ApiUsage
+            Review.query.delete()
+            Product.query.delete()
+            Category.query.delete()
+            ApiUsage.query.delete()
+            db.session.commit()
+        else:
+            run_migrations()
+
+        ensure_categories()
+
+        client = SerpApiClient()
+        total_synced = 0
+        total_updated = 0
+        total_skipped = 0
+        api_calls = 0
+
+        for category_slug, queries in CATEGORY_SEARCHES.items():
+            category_name = ALL_CATEGORIES.get(category_slug, category_slug)
+            print(f"\n{'='*50}")
+            print(f"Category: {category_name}")
+
+            for query in queries:
+                print(f"\n  Searching: \"{query}\"")
+                api_calls += 1
+
+                try:
+                    products = client.search_amazon_products(query)
+                except Exception as e:
+                    print(f"  Error: {e}")
+                    continue
+
+                if not products:
+                    print("  No results (possibly rate limited)")
+                    continue
+
+                # Limit results per query
+                products = products[:limit_per_query]
+                print(f"  Found {len(products)} products")
+
+                for p in products:
+                    asin = p.get("asin")
+                    if not asin:
+                        continue
+
+                    title = p.get("title", "").strip()
+                    if not title:
+                        continue
+
+                    price = p.get("price")
+                    rating = convert_amazon_rating(p.get("rating"))
+                    reviews_count = p.get("reviews_count") or 0
+                    image_url = p.get("image", "")
+                    link = p.get("link", "")
+
+                    # Skip products without a price
+                    if not price or price <= 0:
+                        total_skipped += 1
+                        continue
+
+                    # Upsert by ASIN
+                    existing = Product.query.filter_by(amazon_asin=asin).first()
+                    if existing:
+                        existing.name = title
+                        existing.price = price
+                        existing.rating = rating
+                        existing.review_count = reviews_count
+                        existing.image_url = image_url
+                        existing.source_url = link
+                        existing.updated_at = datetime.utcnow()
+                        total_updated += 1
+                    else:
+                        product = Product(
+                            name=title,
+                            description="",  # Filled when reviews are fetched
+                            category=category_slug,
+                            price=price,
+                            rating=rating,
+                            review_count=reviews_count,
+                            image_url=image_url,
+                            source_url=link,
+                            amazon_asin=asin,
+                        )
+                        db.session.add(product)
+                        total_synced += 1
+
+                db.session.commit()
+
+        # Update category product counts
+        for slug in ALL_CATEGORIES:
+            cat = Category.query.filter_by(slug=slug).first()
+            if cat:
+                cat.product_count = Product.query.filter_by(category=slug).count()
+        db.session.commit()
+
+        # Print summary
+        total_in_db = Product.query.count()
+        usage = client.get_usage_stats()
+
+        print(f"\n{'='*50}")
+        print(f"Sync complete!")
+        print(f"  SerpApi calls used: {api_calls}")
+        print(f"  New products: {total_synced}")
+        print(f"  Updated products: {total_updated}")
+        print(f"  Skipped (no price): {total_skipped}")
+        print(f"  Total in database: {total_in_db}")
+
+        print(f"\nSerpApi monthly usage: {usage['used']}/{usage['limit']} ({usage['remaining']} remaining)")
+
+        print(f"\nProducts by category:")
+        for slug, name in ALL_CATEGORIES.items():
+            count = Product.query.filter_by(category=slug).count()
+            if count > 0:
+                print(f"  {name}: {count}")
+
+        if total_in_db > 0:
+            print(f"\nTop rated products:")
+            top = Product.query.order_by(Product.rating.desc()).limit(5).all()
+            for p in top:
+                print(f"  {p.rating}/10 - {p.name[:60]} (${float(p.price):.2f})")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Sync products from Amazon via SerpApi")
+    parser.add_argument("--clean", action="store_true", help="Clear existing data first")
+    parser.add_argument("--limit", type=int, default=15, help="Max products per search query (default: 15)")
+    args = parser.parse_args()
+
+    print("Starting Amazon product sync via SerpApi...")
+    sync_products(limit_per_query=args.limit, clean=args.clean)
+    print("\nDone! Run 'python app.py' to start the server.")

--- a/backend/sync.py
+++ b/backend/sync.py
@@ -116,8 +116,14 @@ def run_migrations():
         try:
             db.session.execute(db.text(sql))
             db.session.commit()
-        except Exception:
-            db.session.rollback()
+        except Exception as e:
+            error_msg = str(e).lower()
+            if 'duplicate column' in error_msg or 'already exists' in error_msg:
+                db.session.rollback()
+            else:
+                print(f"Migration failed: {sql}")
+                print(f"Error: {e}")
+                raise
 
 
 def ensure_categories():


### PR DESCRIPTION
Add external API config and extend models for real data

- Add requests to requirements.txt
- Add SerpApi config vars to config.py and .env.example
- Extend Product with amazon_asin, bestbuy_sku, reviews_fetched_at
- Extend Review with source_rating for original star ratings
- Add ApiUsage model for tracking API call limits
- Add .claude/settings.local.json to .gitignore

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Add SerpApi and Best Buy service clients with review caching

- Add SerpApiClient for Amazon product search and review fetching
- Add BestBuyClient for product catalog queries (future use)
- Add review_service with on-demand fetch, 7-day caching, rate limiting

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Add product sync script and on-demand review fetching

- Add sync.py CLI to populate 800+ products from Amazon via SerpApi
- Update product detail route to fetch reviews on-demand from Amazon
- Add /api/api-usage endpoint for monitoring SerpApi budget

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>