### PR TITLE
Add pagination UI and sort controls to product grids

### DIFF
--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -1,0 +1,82 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from './Button';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  isLoading?: boolean;
+}
+
+function getPageRange(current: number, total: number): (number | 'ellipsis')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+  const pages: (number | 'ellipsis')[] = [1];
+
+  if (current > 3) pages.push('ellipsis');
+
+  for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) {
+    pages.push(i);
+  }
+
+  if (current < total - 2) pages.push('ellipsis');
+
+  pages.push(total);
+  return pages;
+}
+
+export const Pagination = ({ currentPage, totalPages, onPageChange, isLoading = false }: PaginationProps) => {
+  if (totalPages <= 1) return null;
+
+  const pages = getPageRange(currentPage, totalPages);
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className="flex items-center justify-center gap-1 mt-10"
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1 || isLoading}
+        aria-label="Previous page"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      {pages.map((page, idx) =>
+        page === 'ellipsis' ? (
+          <span
+            key={`ellipsis-${idx}`}
+            className="px-2 text-slate-400 dark:text-slate-500 text-sm select-none"
+          >
+            &hellip;
+          </span>
+        ) : (
+          <Button
+            key={page}
+            variant={page === currentPage ? 'primary' : 'ghost'}
+            size="sm"
+            onClick={() => onPageChange(page)}
+            disabled={isLoading}
+            aria-label={`Page ${page}`}
+            aria-current={page === currentPage ? 'page' : undefined}
+          >
+            {page}
+          </Button>
+        )
+      )}
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages || isLoading}
+        aria-label="Next page"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </nav>
+  );
+};

--- a/frontend/src/components/ui/SortSelect.tsx
+++ b/frontend/src/components/ui/SortSelect.tsx
@@ -1,0 +1,34 @@
+import { ArrowUpDown } from 'lucide-react';
+
+export interface SortOption {
+  value: string;
+  label: string;
+}
+
+interface SortSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: SortOption[];
+}
+
+export const SortSelect = ({ value, onChange, options }: SortSelectProps) => {
+  return (
+    <div className="relative inline-flex items-center">
+      <ArrowUpDown className="absolute left-3 h-4 w-4 text-slate-400 dark:text-slate-500 pointer-events-none" />
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="appearance-none pl-9 pr-8 py-2 text-sm font-medium rounded-lg bg-white dark:bg-dark-surface border border-surface-border dark:border-dark-border text-slate-700 dark:text-slate-200 hover:border-brand-400 dark:hover:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:focus:ring-offset-dark transition-colors cursor-pointer"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <span className="absolute right-2.5 pointer-events-none text-slate-400 dark:text-slate-500 text-xs">
+        ▾
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import api from '../config/api';
 import type { ProductListResponse } from '../types/product';
 
-interface UseProductsParams {
+export interface UseProductsParams {
   page?: number;
   limit?: number;
   category?: string;

--- a/frontend/src/pages/CategoryProductsPage.tsx
+++ b/frontend/src/pages/CategoryProductsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useProducts } from '../hooks/useProducts';
 import type { UseProductsParams } from '../hooks/useProducts';
@@ -30,8 +30,12 @@ export const CategoryProductsPage = () => {
   });
 
   // Reset to page 1 when navigating to a different category
+  const prevSlugRef = useRef(slug);
   useEffect(() => {
-    setSearchParams({ page: '1', sort: 'rating_desc' }, { replace: true });
+    if (prevSlugRef.current !== slug) {
+      setSearchParams({ page: '1', sort: 'rating_desc' }, { replace: true });
+      prevSlugRef.current = slug;
+    }
   }, [slug, setSearchParams]);
 
   useEffect(() => {

--- a/frontend/src/pages/CategoryProductsPage.tsx
+++ b/frontend/src/pages/CategoryProductsPage.tsx
@@ -1,16 +1,52 @@
-import { useParams, Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useProducts } from '../hooks/useProducts';
+import type { UseProductsParams } from '../hooks/useProducts';
 import { ProductGrid } from '../components/products/ProductGrid';
+import { Pagination } from '../components/ui/Pagination';
+import { SortSelect, type SortOption } from '../components/ui/SortSelect';
 import { ChevronRight } from 'lucide-react';
+
+const SORT_OPTIONS: SortOption[] = [
+  { value: 'rating_desc', label: 'Highest Rated' },
+  { value: 'rating_asc', label: 'Lowest Rated' },
+  { value: 'price_desc', label: 'Price: High to Low' },
+  { value: 'price_asc', label: 'Price: Low to High' },
+  { value: 'newest', label: 'Newest' },
+];
 
 export const CategoryProductsPage = () => {
   const { slug } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const sort = (searchParams.get('sort') || 'rating_desc') as NonNullable<UseProductsParams['sort']>;
+
   const { data, isLoading, error } = useProducts({
     category: slug,
-    sort: 'rating_desc',
+    sort,
+    page,
+    limit: 20,
   });
 
-  const categoryName = slug?.replace('-', ' ') || '';
+  // Reset to page 1 when navigating to a different category
+  useEffect(() => {
+    setSearchParams({ page: '1', sort: 'rating_desc' }, { replace: true });
+  }, [slug, setSearchParams]);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [page]);
+
+  const handlePageChange = (newPage: number) => {
+    setSearchParams({ page: String(newPage), sort });
+  };
+
+  const handleSortChange = (newSort: string) => {
+    setSearchParams({ page: '1', sort: newSort });
+  };
+
+  const categoryName = slug?.replace(/-/g, ' ') || '';
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
@@ -27,13 +63,21 @@ export const CategoryProductsPage = () => {
         <span className="text-slate-900 dark:text-slate-100 capitalize">{categoryName}</span>
       </div>
 
-      <div className="mb-8">
-        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100 mb-2 capitalize">
-          {categoryName}
-        </h1>
-        <p className="text-slate-500 dark:text-slate-400">
-          {data?.total || 0} products found
-        </p>
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100 capitalize">
+            {categoryName}
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-1">
+            {data?.total ?? 0} products found
+          </p>
+        </div>
+        <SortSelect
+          value={sort}
+          onChange={handleSortChange}
+          options={SORT_OPTIONS}
+        />
       </div>
 
       {error && (
@@ -44,6 +88,13 @@ export const CategoryProductsPage = () => {
 
       <ProductGrid
         products={data?.products || []}
+        isLoading={isLoading}
+      />
+
+      <Pagination
+        currentPage={page}
+        totalPages={data?.pages ?? 1}
+        onPageChange={handlePageChange}
         isLoading={isLoading}
       />
     </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,9 +1,39 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useProducts } from '../hooks/useProducts';
+import type { UseProductsParams } from '../hooks/useProducts';
 import { ProductGrid } from '../components/products/ProductGrid';
+import { Pagination } from '../components/ui/Pagination';
+import { SortSelect, type SortOption } from '../components/ui/SortSelect';
 import { Star } from 'lucide-react';
 
+const SORT_OPTIONS: SortOption[] = [
+  { value: 'rating_desc', label: 'Highest Rated' },
+  { value: 'rating_asc', label: 'Lowest Rated' },
+  { value: 'price_desc', label: 'Price: High to Low' },
+  { value: 'price_asc', label: 'Price: Low to High' },
+  { value: 'newest', label: 'Newest' },
+];
+
 export const Home = () => {
-  const { data, isLoading, error } = useProducts({ sort: 'rating_desc', limit: 20 });
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const sort = (searchParams.get('sort') || 'rating_desc') as NonNullable<UseProductsParams['sort']>;
+
+  const { data, isLoading, error } = useProducts({ sort, limit: 20, page });
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [page]);
+
+  const handlePageChange = (newPage: number) => {
+    setSearchParams({ page: String(newPage), sort });
+  };
+
+  const handleSortChange = (newSort: string) => {
+    setSearchParams({ page: '1', sort: newSort });
+  };
 
   return (
     <div>
@@ -24,9 +54,23 @@ export const Home = () => {
 
       {/* Product Grid */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
-        <h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100 mb-6">
-          Top Rated Products
-        </h2>
+        <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+              Top Rated Products
+            </h2>
+            {data && (
+              <p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">
+                {data.total} products
+              </p>
+            )}
+          </div>
+          <SortSelect
+            value={sort}
+            onChange={handleSortChange}
+            options={SORT_OPTIONS}
+          />
+        </div>
 
         {error && (
           <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-xl mb-6">
@@ -36,6 +80,13 @@ export const Home = () => {
 
         <ProductGrid
           products={data?.products || []}
+          isLoading={isLoading}
+        />
+
+        <Pagination
+          currentPage={page}
+          totalPages={data?.pages ?? 1}
+          onPageChange={handlePageChange}
           isLoading={isLoading}
         />
       </div>


### PR DESCRIPTION
Add pagination UI and sort controls to product grids

Adds reusable Pagination and SortSelect components. Both Home and
CategoryProductsPage now support page navigation and sorting (by rating
and price) with URL-driven state via useSearchParams for shareable links.
Also fixes CategoryProductsPage only replacing the first hyphen in slugs.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Update CLAUDE.md with full project docs and commit rules

Expands CLAUDE.md with backend details (models, endpoints, services,
data pipeline), frontend architecture, and not-yet-implemented list.
Adds rule to never commit .claude/commands/ or settings.local.json.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>