### PR TITLE
Add search query support to products and categories endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,14 @@ npm run preview            # preview production build
 - Use `gt submit` to push and create/update PRs
 - Use `gt log` to view the stack
 - Only fall back to `git` for operations Graphite doesn't support (e.g., `git init`, `git remote`)
+- **NEVER commit `.claude/commands/` or `.claude/settings.local.json`** — these are local-only files. Always keep them unstaged.
+
+### Branching Strategy
+
+- **`frontend-develop`** — Long-lived development branch for all frontend work. All frontend feature branches should be created off this branch.
+- **`backend-develop`** — Long-lived development branch for all backend work. All backend feature branches should be created off this branch.
+- **`master`** — Stable main branch. `frontend-develop` and `backend-develop` merge into `master` when ready.
+- When creating a new feature branch, always branch off the correct develop branch:
+  - Frontend changes → branch off `frontend-develop`
+  - Backend changes → branch off `backend-develop`
+  - Full-stack changes → coordinate across both develop branches

--- a/backend/routes/categories.py
+++ b/backend/routes/categories.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from models.category import Category
 from models.product import Product
 from schemas.product_schema import CategoryResponse
@@ -38,6 +38,25 @@ def get_category_products(slug):
             "products": products_data,
             "total": len(products_data),
         }), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@categories_bp.route("/search", methods=["GET"])
+def search_categories():
+    """Search categories by name"""
+    try:
+        search = request.args.get("q", "").strip()
+        if not search:
+            return jsonify([]), 200
+
+        search_pattern = f"%{search}%"
+        categories = Category.query.filter(
+            Category.name.like(search_pattern)
+        ).order_by(Category.name).limit(5).all()
+
+        return jsonify([cat.to_dict() for cat in categories]), 200
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
- Add `q` query param to GET /api/products for LIKE filtering on name, description, and category
- Add GET /api/categories/search endpoint for category name matching
- Update CLAUDE.md with branching strategy and .claude exclusion rules