### PR TITLE
Add AI chatbot frontend and review fixes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,3 +7,6 @@ SERPAPI_MONTHLY_LIMIT=250
 
 # How many days to cache reviews before re-fetching
 REVIEW_CACHE_DAYS=7
+
+# Anthropic Claude API for AI chat on product detail pages - https://console.anthropic.com
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/backend/config.py
+++ b/backend/config.py
@@ -27,3 +27,6 @@ class Config:
     SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY", "")
     SERPAPI_MONTHLY_LIMIT = int(os.getenv("SERPAPI_MONTHLY_LIMIT", "250"))
     REVIEW_CACHE_DAYS = int(os.getenv("REVIEW_CACHE_DAYS", "7"))
+
+    # Anthropic Claude API
+    ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv>=1.0.0
 sqlalchemy>=2.0.0
 pydantic>=2.0.0
 requests>=2.31.0
+anthropic>=0.40.0

--- a/backend/routes/products.py
+++ b/backend/routes/products.py
@@ -132,6 +132,9 @@ def chat_with_product(product_id):
     if not user_message:
         return jsonify({"error": "message is required"}), 400
 
+    if len(user_message) > 2000:
+        return jsonify({"error": "Message too long (max 2000 characters)"}), 400
+
     raw_history = body.get("history", [])
 
     from services.chat_service import build_system_prompt, cap_history, validate_history

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,0 +1,90 @@
+"""Service for building AI chat context and managing conversation limits."""
+
+MAX_REVIEW_CHARS = 500
+MAX_REVIEWS_IN_CONTEXT = 20
+MAX_HISTORY_MESSAGES = 10
+
+
+def build_system_prompt(product_data: dict) -> str:
+    """Build a system prompt from product.to_dict(include_reviews=True) output."""
+    name = product_data.get("name", "Unknown Product")
+    description = product_data.get("description") or "No description provided."
+    category = product_data.get("category") or "Uncategorized"
+    price = product_data.get("price", 0)
+    rating = product_data.get("rating", 0)
+    review_count = product_data.get("review_count", 0)
+    reviews = product_data.get("reviews", [])
+
+    product_block = (
+        f"Product: {name}\n"
+        f"Category: {category}\n"
+        f"Price: ${price:.2f}\n"
+        f"Rating: {rating}/10 (based on {review_count} reviews)\n"
+        f"Description: {description}"
+    )
+
+    sorted_reviews = sorted(
+        reviews,
+        key=lambda r: r.get("sentiment_score", 0.5),
+        reverse=True,
+    )
+    selected = sorted_reviews[:MAX_REVIEWS_IN_CONTEXT]
+
+    review_lines = []
+    for i, review in enumerate(selected, start=1):
+        source = review.get("source", "unknown").upper()
+        sentiment = review.get("sentiment_score", 0.5)
+        text = (review.get("text") or "").strip()
+        if len(text) > MAX_REVIEW_CHARS:
+            text = text[:MAX_REVIEW_CHARS] + "..."
+
+        pros = review.get("pros", [])
+        cons = review.get("cons", [])
+
+        line = f"[Review {i} | Source: {source} | Sentiment: {sentiment:.2f}]\n{text}"
+        if pros:
+            line += f"\nPros: {', '.join(pros)}"
+        if cons:
+            line += f"\nCons: {', '.join(cons)}"
+        review_lines.append(line)
+
+    reviews_block = "\n\n".join(review_lines) if review_lines else "No reviews available."
+
+    return f"""You are a helpful product research assistant for Revu AI, an AI-powered product review aggregator.
+
+You have been given detailed information about a specific product along with real customer reviews. Your job is to help the user understand this product — answer questions about its features, quality, value, common issues, and whether it's a good fit for their needs.
+
+Be concise, honest, and grounded in the review data. If a question cannot be answered from the provided information, say so clearly.
+
+=== PRODUCT INFORMATION ===
+{product_block}
+
+=== CUSTOMER REVIEWS ({len(selected)} of {review_count} total) ===
+{reviews_block}"""
+
+
+def cap_history(history: list) -> list:
+    """Keep only the last MAX_HISTORY_MESSAGES messages."""
+    if len(history) <= MAX_HISTORY_MESSAGES:
+        return history
+    return history[-MAX_HISTORY_MESSAGES:]
+
+
+def validate_history(raw_history: list) -> tuple[list, str | None]:
+    """Validate and sanitize conversation history from the request body."""
+    if not isinstance(raw_history, list):
+        return [], "history must be a list"
+
+    sanitized = []
+    for i, msg in enumerate(raw_history):
+        if not isinstance(msg, dict):
+            return [], f"history[{i}] must be an object"
+        role = msg.get("role")
+        content = msg.get("content")
+        if role not in ("user", "assistant"):
+            return [], f"history[{i}].role must be 'user' or 'assistant'"
+        if not isinstance(content, str) or not content.strip():
+            return [], f"history[{i}].content must be a non-empty string"
+        sanitized.append({"role": role, "content": content})
+
+    return sanitized, None

--- a/backend/services/review_service.py
+++ b/backend/services/review_service.py
@@ -1,9 +1,13 @@
 """Service for fetching and caching product reviews from SerpApi"""
+import logging
 from datetime import datetime, timedelta
 from flask import current_app
 from models.review import Review
 from services.serpapi_client import SerpApiClient
+from services.sentiment_service import analyze_reviews
 from utils.database import db
+
+logger = logging.getLogger(__name__)
 
 
 def fetch_reviews_for_product(product):
@@ -45,31 +49,67 @@ def fetch_reviews_for_product(product):
     # Step 3: Delete old Amazon reviews for this product
     Review.query.filter_by(product_id=product.id, source="amazon").delete()
 
-    # Step 4: Insert new reviews
-    for raw in raw_reviews:
+    # Step 4: Prepare reviews for AI analysis
+    review_inputs = []
+    for idx, raw in enumerate(raw_reviews):
+        review_inputs.append({
+            "id": idx,
+            "text": raw.get("text", raw.get("title", "No review text")),
+            "star_rating": raw.get("rating", 3),
+        })
+
+    # Step 5: Attempt AI sentiment analysis (returns None on failure)
+    ai_results = None
+    try:
+        ai_results = analyze_reviews(review_inputs)
+    except Exception as e:
+        logger.warning("AI sentiment analysis failed for product %s: %s", product.id, e)
+
+    # Build lookup from AI results (keyed by index)
+    ai_lookup = {}
+    if ai_results:
+        for result in ai_results:
+            ai_lookup[result["id"]] = result
+
+    # Step 6: Create Review objects with AI or fallback data
+    for idx, raw in enumerate(raw_reviews):
         star_rating = raw.get("rating")
-        sentiment = SerpApiClient.convert_sentiment(star_rating)
+        review_text = raw.get("text", raw.get("title", "No review text"))
+
+        ai = ai_lookup.get(idx)
+        if ai:
+            sentiment = ai["sentiment_score"]
+            pros = ai["pros"]
+            cons = ai["cons"]
+        else:
+            # Fallback: star-rating-based sentiment (original formula)
+            sentiment = SerpApiClient.convert_sentiment(star_rating)
+            pros = [raw.get("title", "Positive review")] if sentiment > 0.6 else []
+            cons = [raw.get("title", "Negative review")] if sentiment < 0.3 else []
 
         review = Review(
             product_id=product.id,
             source="amazon",
-            text=raw.get("text", raw.get("title", "No review text")),
+            text=review_text,
             sentiment_score=sentiment,
             source_rating=float(star_rating) if star_rating else None,
         )
-
-        # Set basic pros/cons based on sentiment
-        if sentiment > 0.6:
-            review.set_pros([raw.get("title", "Positive review")])
-        elif sentiment < 0.3:
-            review.set_cons([raw.get("title", "Negative review")])
-
+        review.set_pros(pros)
+        review.set_cons(cons)
         db.session.add(review)
 
-    # Step 5: Update product metadata
+    # Step 7: Update product metadata and recalculate rating
     product.reviews_fetched_at = datetime.utcnow()
-    all_reviews = Review.query.filter_by(product_id=product.id).all()
+    db.session.flush()
+
+    all_reviews = Review.query.filter_by(product_id=product.id, source="amazon").all()
     product.review_count = len(all_reviews)
+
+    if all_reviews:
+        avg_sentiment = sum(r.sentiment_score for r in all_reviews) / len(all_reviews)
+        product.rating = round(avg_sentiment * 10, 1)
+    else:
+        product.rating = 0.0
 
     db.session.commit()
     return True

--- a/backend/services/sentiment_service.py
+++ b/backend/services/sentiment_service.py
@@ -116,7 +116,7 @@ def analyze_reviews_batch(review_texts):
     try:
         response = client.messages.create(
             model="claude-haiku-4-5-20251001",
-            max_tokens=1024,
+            max_tokens=2048,
             system=SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}],
             tools=[ANALYSIS_TOOL],

--- a/backend/services/sentiment_service.py
+++ b/backend/services/sentiment_service.py
@@ -1,0 +1,165 @@
+"""AI-powered sentiment analysis and pros/cons extraction using Claude API."""
+import logging
+import anthropic
+from flask import current_app
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 10
+
+SYSTEM_PROMPT = (
+    "You are a product review analyst. Analyze each customer review and determine:\n"
+    "1. A sentiment score from 0.0 (very negative) to 1.0 (very positive). "
+    "Consider the full text, not just the star rating.\n"
+    "2. Specific pros mentioned (concrete benefits, features, or positive experiences). "
+    "1-3 items, each under 10 words.\n"
+    "3. Specific cons mentioned (concrete problems, missing features, or negative experiences). "
+    "1-3 items, each under 10 words.\n\n"
+    "If a review is entirely positive, cons can be an empty list (and vice versa). "
+    "Focus on extracting actionable, specific insights rather than generic statements."
+)
+
+ANALYSIS_TOOL = {
+    "name": "submit_review_analysis",
+    "description": "Submit the sentiment analysis results for a batch of product reviews.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "reviews": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "description": "The review index from the input",
+                        },
+                        "sentiment_score": {
+                            "type": "number",
+                            "description": "Sentiment score from 0.0 (very negative) to 1.0 (very positive)",
+                        },
+                        "pros": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "1-3 short specific pros mentioned in the review (each under 10 words)",
+                        },
+                        "cons": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "1-3 short specific cons mentioned in the review (each under 10 words)",
+                        },
+                    },
+                    "required": ["id", "sentiment_score", "pros", "cons"],
+                },
+            }
+        },
+        "required": ["reviews"],
+    },
+}
+
+
+class SentimentAnalysisError(Exception):
+    """Raised when AI sentiment analysis fails."""
+    pass
+
+
+def _build_prompt(reviews):
+    """Build the user message for a batch of reviews."""
+    lines = ["Analyze the following product reviews:\n"]
+    for r in reviews:
+        lines.append(f"[Review {r['id']}] (Star rating: {r['star_rating']}/5)")
+        lines.append(r["text"])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _parse_response(reviews_data):
+    """Validate and normalize structured output from Claude."""
+    results = []
+    for item in reviews_data:
+        result = {
+            "id": item.get("id"),
+            "sentiment_score": max(0.0, min(1.0, float(item.get("sentiment_score", 0.5)))),
+            "pros": [],
+            "cons": [],
+        }
+        for pro in item.get("pros", [])[:3]:
+            if isinstance(pro, str) and pro.strip():
+                result["pros"].append(pro.strip()[:100])
+        for con in item.get("cons", [])[:3]:
+            if isinstance(con, str) and con.strip():
+                result["cons"].append(con.strip()[:100])
+        results.append(result)
+    return results
+
+
+def analyze_reviews_batch(review_texts):
+    """
+    Analyze a batch of reviews (up to BATCH_SIZE) using Claude Haiku.
+
+    Args:
+        review_texts: List of dicts with "id", "text", "star_rating" keys.
+
+    Returns:
+        List of dicts with "id", "sentiment_score", "pros", "cons" keys.
+
+    Raises:
+        SentimentAnalysisError on any failure.
+    """
+    api_key = current_app.config.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise SentimentAnalysisError("ANTHROPIC_API_KEY not configured")
+
+    client = anthropic.Anthropic(api_key=api_key)
+    user_prompt = _build_prompt(review_texts)
+
+    try:
+        response = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1024,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}],
+            tools=[ANALYSIS_TOOL],
+            tool_choice={"type": "tool", "name": "submit_review_analysis"},
+        )
+    except anthropic.APIConnectionError as e:
+        raise SentimentAnalysisError(f"Could not connect to Claude API: {e}")
+    except anthropic.RateLimitError as e:
+        raise SentimentAnalysisError(f"Claude API rate limit reached: {e}")
+    except anthropic.AuthenticationError as e:
+        raise SentimentAnalysisError(f"Invalid Anthropic API key: {e}")
+    except Exception as e:
+        raise SentimentAnalysisError(f"Claude API call failed: {e}")
+
+    for block in response.content:
+        if block.type == "tool_use" and block.name == "submit_review_analysis":
+            return _parse_response(block.input.get("reviews", []))
+
+    raise SentimentAnalysisError("No tool_use block found in Claude response")
+
+
+def analyze_reviews(review_texts):
+    """
+    Public entry point. Splits reviews into batches, analyzes each.
+
+    Returns:
+        Combined results list on success, or None if any batch fails
+        (signaling caller to use fallback for ALL reviews).
+    """
+    if not review_texts:
+        return []
+
+    all_results = []
+    for i in range(0, len(review_texts), BATCH_SIZE):
+        batch = review_texts[i:i + BATCH_SIZE]
+        try:
+            batch_results = analyze_reviews_batch(batch)
+            all_results.extend(batch_results)
+        except SentimentAnalysisError as e:
+            logger.warning(
+                "AI sentiment batch %d-%d failed, falling back: %s",
+                i, i + len(batch), e,
+            )
+            return None
+
+    return all_results

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -1,0 +1,264 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Send, Bot, User, Loader2 } from 'lucide-react';
+import { Button } from '../ui/Button';
+import type { ChatMessage } from '../../types/chat';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
+
+interface ChatWidgetProps {
+  productId: string;
+}
+
+const makeWelcomeMessage = (): ChatMessage => ({
+  id: crypto.randomUUID(),
+  role: 'assistant',
+  content:
+    "Hi! I've analyzed this product's reviews. Ask me anything — pros and cons, how it compares, whether it's right for your use case, or common issues buyers mention.",
+});
+
+export const ChatWidget = ({ productId }: ChatWidgetProps) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([makeWelcomeMessage()]);
+  const [input, setInput] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const sendMessage = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isStreaming) return;
+
+    const historyToSend = messages
+      .slice(1)
+      .filter((m) => !m.isError)
+      .map((m) => ({ role: m.role, content: m.content }));
+
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: trimmed,
+    };
+
+    const assistantPlaceholder: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'assistant',
+      content: '',
+      isStreaming: true,
+    };
+
+    setMessages((prev) => [...prev, userMessage, assistantPlaceholder]);
+    setInput('');
+    setIsStreaming(true);
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/products/${productId}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: trimmed, history: historyToSend }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
+        throw new Error(errorData.error || `HTTP ${response.status}`);
+      }
+
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split('\n\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const dataStr = line.slice(6).trim();
+
+          if (dataStr === '[DONE]') {
+            setMessages((prev) =>
+              prev.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m)),
+            );
+            break;
+          }
+
+          try {
+            const parsed = JSON.parse(dataStr);
+
+            if (parsed.error) {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.isStreaming
+                    ? { ...m, content: parsed.error, isStreaming: false, isError: true }
+                    : m,
+                ),
+              );
+              break;
+            }
+
+            if (parsed.text) {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.isStreaming ? { ...m, content: m.content + parsed.text } : m,
+                ),
+              );
+            }
+          } catch {
+            // Malformed JSON in SSE data — skip
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
+
+      const errorText =
+        err instanceof Error ? err.message : 'Failed to connect to the AI service.';
+
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.isStreaming
+            ? { ...m, content: errorText, isStreaming: false, isError: true }
+            : m,
+        ),
+      );
+    } finally {
+      setIsStreaming(false);
+      abortControllerRef.current = null;
+      inputRef.current?.focus();
+    }
+  }, [input, isStreaming, messages, productId]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-dark-surface rounded-xl border border-surface-border dark:border-dark-border overflow-hidden flex flex-col">
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-surface-border dark:border-dark-border flex items-center gap-3">
+        <div className="w-8 h-8 rounded-full bg-brand-100 dark:bg-brand-900/30 flex items-center justify-center">
+          <Bot className="h-4 w-4 text-brand-600 dark:text-brand-400" />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+            Ask About This Product
+          </h3>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Powered by Claude AI
+          </p>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="flex flex-col gap-4 p-6 overflow-y-auto max-h-[480px] min-h-[200px]">
+        <AnimatePresence initial={false}>
+          {messages.map((msg) => (
+            <motion.div
+              key={msg.id}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.18, ease: 'easeOut' }}
+              className={`flex gap-3 ${msg.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}
+            >
+              {/* Avatar */}
+              <div
+                className={`w-7 h-7 rounded-full flex-shrink-0 flex items-center justify-center ${
+                  msg.role === 'assistant'
+                    ? 'bg-brand-100 dark:bg-brand-900/30'
+                    : 'bg-slate-100 dark:bg-slate-800'
+                }`}
+              >
+                {msg.role === 'assistant' ? (
+                  <Bot className="h-3.5 w-3.5 text-brand-600 dark:text-brand-400" />
+                ) : (
+                  <User className="h-3.5 w-3.5 text-slate-600 dark:text-slate-400" />
+                )}
+              </div>
+
+              {/* Bubble */}
+              <div
+                className={`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                  msg.role === 'user'
+                    ? 'bg-brand-500 text-white rounded-tr-sm'
+                    : msg.isError
+                      ? 'bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-tl-sm'
+                      : 'bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100 rounded-tl-sm'
+                }`}
+              >
+                {msg.content ||
+                  (msg.isStreaming && (
+                    <span className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400">
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Thinking...
+                    </span>
+                  ))}
+                {msg.isStreaming && msg.content && (
+                  <span className="inline-block w-0.5 h-3.5 bg-current ml-0.5 animate-pulse" />
+                )}
+              </div>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="px-6 py-4 border-t border-surface-border dark:border-dark-border">
+        <div className="flex gap-3 items-end">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about this product..."
+            maxLength={2000}
+            rows={1}
+            disabled={isStreaming}
+            className="flex-1 resize-none rounded-xl border border-surface-border dark:border-dark-border bg-surface-secondary dark:bg-dark-surface-secondary text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed transition-all max-h-32 overflow-y-auto"
+            style={{ minHeight: '42px' }}
+          />
+          <Button
+            onClick={sendMessage}
+            disabled={!input.trim() || isStreaming}
+            size="md"
+            className="flex-shrink-0 h-[42px] w-[42px] !px-0 flex items-center justify-center"
+            aria-label="Send message"
+          >
+            {isStreaming ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+        <p className="text-xs text-slate-400 dark:text-slate-500 mt-2">
+          Press Enter to send
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/products/ProductDetail.tsx
+++ b/frontend/src/components/products/ProductDetail.tsx
@@ -4,6 +4,7 @@ import { RatingBadge } from './RatingBadge';
 import { ProConsList } from '../reviews/ProConsList';
 import { ReviewList } from '../reviews/ReviewList';
 import { Button } from '../ui/Button';
+import { ChatWidget } from '../chat/ChatWidget';
 import { formatPrice } from '../../utils/formatters';
 
 interface ProductDetailProps {
@@ -93,6 +94,9 @@ export const ProductDetail = ({ product }: ProductDetailProps) => {
         </h2>
         <ReviewList reviews={product.reviews} limit={5} />
       </div>
+
+      {/* AI Chat */}
+      <ChatWidget productId={product.id} />
     </div>
   );
 };

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,0 +1,9 @@
+export type ChatRole = 'user' | 'assistant';
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  isStreaming?: boolean;
+  isError?: boolean;
+}


### PR DESCRIPTION
## Summary
- Adds ChatWidget frontend component with streaming SSE, Framer Motion animations, and error handling
- Adds `maxLength=2000` on chat textarea to match backend limit
- Removes duplicate "Ask About This Product" heading (ChatWidget has its own header)
- Bumps sentiment analysis `max_tokens` from 1024 to 2048 to prevent truncation on large review batches
- Adds chat message length validation (reject >2000 chars with 400)

## Test plan
- [x] Frontend build passes (`npm run build`)
- [x] Chat streaming works end-to-end
- [x] Multi-turn conversation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)